### PR TITLE
allow continuous batching to be disabled

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -2599,8 +2599,8 @@ static void server_params_parse(int argc, char ** argv, server_params & sparams,
             }
         } else if (arg == "--embedding" || arg == "--embeddings") {
             params.embedding = true;
-        } else if (arg == "-cb" || arg == "--cont-batching") {
-            params.cont_batching = true;
+        } else if (arg == "-nocb" || arg == "--no-cont-batching") {
+            params.cont_batching = false;
         } else if (arg == "-np" || arg == "--parallel") {
             if (++i >= argc) {
                 invalid_param = true;


### PR DESCRIPTION
68e210b enabled continuous batching by default, but the server would still take the `-cb | --cont-batching` to set the continuous batching to true. I turned those args to `-nocb | --no-cont-batching` so we can disable this behavior in server.